### PR TITLE
Embed Git metadata in container image and expose via new version API

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,11 +37,20 @@ jobs:
                 sed -e 's,/,-,g')" ;;
           esac
 
+          # Record git source and revision
+          GIT_SOURCE=$(git config --get remote.origin.url)
+          GIT_REVISION=$(git rev-parse HEAD)$(git diff --quiet || echo "-dirty")
+
           echo ::set-output name=docker_push::$DOCKER_PUSH
           echo ::set-output name=docker_tag::$DOCKER_TAG
+          echo ::set-output name=git_source::$GIT_SOURCE
+          echo ::set-output name=git_revision::$GIT_REVISION
 
       - name: Build the Docker image
-        run: docker-compose build
+        run: |
+          docker-compose build \
+            --build-arg GIT_SOURCE=${{ steps.init.outputs.git_source }} \
+            --build-arg GIT_REVISION=${{ steps.init.outputs.git_revision }}
 
       - name: Run test suite
         run: docker-compose run sealog-server npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,3 +28,12 @@ EXPOSE 8000
 
 # By default, run in production mode
 CMD [ "npm", "run", "start" ]
+
+# Attach git metadata to this container image
+ARG GIT_SOURCE
+LABEL org.opencontainers.image.source=${GIT_SOURCE}
+ENV GIT_SOURCE=${GIT_SOURCE}
+
+ARG GIT_REVISION
+LABEL org.opencontainers.image.revision=${GIT_REVISION}
+ENV GIT_REVISION=${GIT_REVISION}

--- a/routes/default.js
+++ b/routes/default.js
@@ -2,6 +2,7 @@ const Boom = require('@hapi/boom');
 const Joi = require('@hapi/joi');
 const Fs = require('fs');
 const Path = require('path');
+const Pkg = require('../package.json');
 const Tmp = require('tmp');
 
 const {
@@ -129,6 +130,32 @@ exports.plugin = {
           <div class="panel-heading"><strong>Status Code: 401</strong> - authentication failed</div>\
           <div class="panel-body">Returns JSON object explaining error</div>\
         </div>',
+        response: {
+          status: {}
+        },
+        tags: ['misc','api']
+      }
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/version',
+      handler(request, h) {
+        let response = { version: Pkg.version };
+        if (request.auth.credentials) {
+          if (request.auth.credentials.scope.includes('admin')) {
+            response.git_source = process.env.GIT_SOURCE || 'unknown';
+            response.git_revision = process.env.GIT_REVISION || 'unknown';
+          }
+        }
+        return h.response(response).code(200);
+      },
+      config: {
+        auth: {
+          mode: 'optional',
+          strategy: 'jwt'
+        },
+        description: 'This is route returns the Sealog version. Admin users receive extended information.',
         response: {
           status: {}
         },


### PR DESCRIPTION
This change adds the following labels to the container image:

    org.opencontainers.image.revision  Git commit hash
    org.opencontainers.image.source    Git remote URL

Labels can be viewed using `docker inspect`. To include them when
building, use

    $ docker-compose build \
        --build-arg GIT_SOURCE=$(git config --get remote.origin.url) \
        --build-arg GIT_REVISION=$(git rev-parse HEAD)$(git diff --quiet || echo "-dirty")

Additionally, this change introduces a new /version API which returns
these values. For security reasons, the extended version information is
only available to administrators:

    $ curl -H "Authorization: ..." http://host/sealog-server/version
    {
      "version": "2.1.3",
      "git_source": "git@github.com:WHOIGit/ndsf-sealog-server.git",
      "git_revision": "7dcb19d29266a8132733744f20004bf2ca075808-dirty"
    }