### PR TITLE
build: Switching base layer to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:20-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Moving to a lighter base layer easier to support on the imaging server in its current configuration