### PR TITLE
Allow embargoed products to still be listed

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,25 +17,6 @@ jobs:
       - name: Initialize
         id: init
         run: |
-          # Determine whether to push to Docker Hub based on the event type
-          case "${{ github.event_name }}" in
-            push)
-              DOCKER_PUSH=true ;;
-            *)
-              DOCKER_PUSH=false ;;
-          esac
-
-          # Map git ref branch or tag name to Docker tag version
-          case "${{ github.ref }}" in
-            # Do not push upstream branches and tags to Docker Hub
-            refs/heads/upstream/*|refs/tags/upstream/*)
-              DOCKER_PUSH=false ;;
-            # Do not push pull request branches
-            refs/pulls/*)
-              DOCKER_PUSH=false ;;
-          esac
-
-          echo ::set-output name=docker_push::$DOCKER_PUSH
           echo ::set-output name=docker_repo::whoi/$(basename "${{ github.repository }}" | tr A-Z a-z)
           echo ::set-output name=docker_platforms::linux/amd64,linux/arm64
 
@@ -50,13 +31,6 @@ jobs:
             type=ref,event=tag
             type=ref,event=pr
             type=sha
-
-      - name: Log into registry
-        if: steps.init.outputs.docker_push == 'true'
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       # Enable Docker layer caching in the GitHub Actions cache.
       #
@@ -111,14 +85,60 @@ jobs:
 
           docker compose down
 
+      - name: Update cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  docker-push:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+
+      - name: Initialize
+        id: init
+        run: |
+          echo ::set-output name=docker_repo::whoi/$(basename "${{ github.repository }}" | tr A-Z a-z)
+          echo ::set-output name=docker_platforms::linux/amd64,linux/arm64
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ steps.init.outputs.docker_repo }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha
+
+      - name: Log into registry
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      # Restore the cache warmed by the build-and-test job
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-multi-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-multi-buildx
+
       # Because `docker buildx build` cannot have multiple cache export targets
-      # yet, we build and push separately.
+      # yet, we build and push separately from the test build above.
       #
-      # During the build step (above), we update the GitHub Actions cache. Then
-      # we use this cache to rebuild, pushing both the image and the cache up to
-      # the registry.
-      - name: Push
-        if: steps.init.outputs.docker_push == 'true'
+      # We use the cache warmed by build-and-test, then push both the image and
+      # an updated buildcache up to the registry.
+      - name: Push multi-platform image
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -133,11 +153,6 @@ jobs:
             GIT_REVISION=${{ steps.init.outputs.git_revision }}
 
           cache-from: |
-            type=local,src=/tmp/.buildx-cache-new
+            type=local,src=/tmp/.buildx-cache
           cache-to: |
             type=registry,ref=${{ steps.init.outputs.docker_repo }}:buildcache,mode=max
-
-      - name: Update cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/integration-tests/api_tests.postman_collection.json
+++ b/integration-tests/api_tests.postman_collection.json
@@ -589,6 +589,114 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Create Lowering in Hidden Cruise",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/lowerings",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"lowerings"
+							]
+						},
+						"body": {
+							"mode": "raw",
+							"raw": "{\"lowering_id\": \"cruise-hidden-lowering\", \"start_ts\": \"2023-06-03T00:00:00.000Z\", \"stop_ts\": \"2023-06-04T00:00:00.000Z\", \"lowering_location\": \"Test Location\", \"lowering_additional_meta\": {}, \"lowering_tags\": [\"test-tag\"]}"
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Response contains lowering ID\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property(\"insertedId\");",
+									"    pm.environment.set(\"cruiseHiddenLoweringId\", jsonData.insertedId);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Create Event in Cruise-Hidden Lowering",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/events",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"events"
+							]
+						},
+						"body": {
+							"mode": "raw",
+							"raw": "{\"event_author\": \"Admin\", \"ts\": \"2023-06-03T12:00:00.000Z\", \"event_value\": \"Cruise Hidden Test Event\", \"event_options\": [{\"event_option_name\": \"Test Option\", \"event_option_value\": \"Test Value\"}], \"event_free_text\": \"Event in a lowering whose parent cruise is hidden\"}"
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Response contains event ID\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property(\"insertedId\");",
+									"    pm.environment.set(\"cruiseHiddenEventId\", jsonData.insertedId);",
+									"});"
+								]
+							}
+						}
+					]
 				}
 			]
 		},
@@ -3062,7 +3170,7 @@
 					},
 					"response": []
 				},
-								{
+				{
 					"name": "Anonymous Get Events",
 					"event": [
 						{
@@ -3343,7 +3451,7 @@
 			"name": "Access Control - Hidden Field Tests",
 			"item": [
 				{
-					"name": "Guest Cannot See Hidden Cruises in List",
+					"name": "Guest Sees Hidden Cruises in List with access_denied",
 					"event": [
 						{
 							"listen": "test",
@@ -3353,12 +3461,21 @@
 									"    pm.response.to.have.status(200);",
 									"});",
 									"",
-									"pm.test(\"Hidden cruise not in response\", function () {",
+									"pm.test(\"Hidden cruise in response with access_denied flag\", function () {",
 									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData).to.be.an('array');",
-									"    var hiddenCruiseId = pm.environment.get('hiddenCruiseId');",
+									"    pm.expect(jsonData).to.be.an(\"array\");",
+									"    var hiddenCruiseId = pm.environment.get(\"hiddenCruiseId\");",
 									"    var found = jsonData.find(c => c.id === hiddenCruiseId);",
-									"    pm.expect(found).to.be.undefined;",
+									"    pm.expect(found).to.not.be.undefined;",
+									"    pm.expect(found.access_denied).to.eql(true);",
+									"});",
+									"",
+									"pm.test(\"Access-denied cruise has only id, cruise_id, and access_denied\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    var hiddenCruiseId = pm.environment.get(\"hiddenCruiseId\");",
+									"    var found = jsonData.find(c => c.id === hiddenCruiseId);",
+									"    var keys = Object.keys(found).sort();",
+									"    pm.expect(keys).to.eql([\"access_denied\", \"cruise_id\", \"id\", \"start_ts\", \"stop_ts\"]);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -3389,7 +3506,7 @@
 					"response": []
 				},
 				{
-					"name": "Guest Cannot See Hidden Lowerings in List",
+					"name": "Guest Sees Hidden Lowerings in List with access_denied",
 					"event": [
 						{
 							"listen": "test",
@@ -3399,12 +3516,21 @@
 									"    pm.response.to.have.status(200);",
 									"});",
 									"",
-									"pm.test(\"Hidden lowering not in response\", function () {",
+									"pm.test(\"Hidden lowering in response with access_denied flag\", function () {",
 									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData).to.be.an('array');",
-									"    var hiddenLoweringId = pm.environment.get('hiddenLoweringId');",
+									"    pm.expect(jsonData).to.be.an(\"array\");",
+									"    var hiddenLoweringId = pm.environment.get(\"hiddenLoweringId\");",
 									"    var found = jsonData.find(l => l.id === hiddenLoweringId);",
-									"    pm.expect(found).to.be.undefined;",
+									"    pm.expect(found).to.not.be.undefined;",
+									"    pm.expect(found.access_denied).to.eql(true);",
+									"});",
+									"",
+									"pm.test(\"Access-denied lowering has only id, lowering_id, and access_denied\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    var hiddenLoweringId = pm.environment.get(\"hiddenLoweringId\");",
+									"    var found = jsonData.find(l => l.id === hiddenLoweringId);",
+									"    var keys = Object.keys(found).sort();",
+									"    pm.expect(keys).to.eql([\"access_denied\", \"id\", \"lowering_id\", \"start_ts\"]);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -3511,6 +3637,162 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Guest Sees Lowering of Hidden Cruise with access_denied",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{guest_jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/lowerings",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"lowerings"
+							]
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Lowering of hidden cruise has access_denied flag\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.an(\"array\");",
+									"    var targetId = pm.environment.get(\"cruiseHiddenLoweringId\");",
+									"    var found = jsonData.find(l => l.id === targetId);",
+									"    pm.expect(found).to.not.be.undefined;",
+									"    pm.expect(found.access_denied).to.eql(true);",
+									"});",
+									"",
+									"pm.test(\"Cruise-denied lowering has only id, lowering_id, and access_denied\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    var targetId = pm.environment.get(\"cruiseHiddenLoweringId\");",
+									"    var found = jsonData.find(l => l.id === targetId);",
+									"    var keys = Object.keys(found).sort();",
+									"    pm.expect(keys).to.eql([\"access_denied\", \"id\", \"lowering_id\", \"start_ts\"]);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Guest Cannot Access Events for Lowering in Hidden Cruise",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{guest_jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/events/bylowering/{{cruiseHiddenLoweringId}}",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"events",
+								"bylowering",
+								"{{cruiseHiddenLoweringId}}"
+							]
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([401]);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Guest Sees Lowerings via bycruise for Hidden Cruise with access_denied",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{guest_jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/lowerings/bycruise/{{hiddenCruiseId}}",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"lowerings",
+								"bycruise",
+								"{{hiddenCruiseId}}"
+							]
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Lowerings have access_denied flag\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.an(\"array\");",
+									"    pm.expect(jsonData.length).to.be.above(0);",
+									"    var targetId = pm.environment.get(\"cruiseHiddenLoweringId\");",
+									"    var found = jsonData.find(l => l.id === targetId);",
+									"    pm.expect(found).to.not.be.undefined;",
+									"    pm.expect(found.access_denied).to.eql(true);",
+									"});",
+									"",
+									"pm.test(\"Bycruise denied lowering has only id, lowering_id, and access_denied\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    var targetId = pm.environment.get(\"cruiseHiddenLoweringId\");",
+									"    var found = jsonData.find(l => l.id === targetId);",
+									"    var keys = Object.keys(found).sort();",
+									"    pm.expect(keys).to.eql([\"access_denied\", \"id\", \"lowering_id\", \"start_ts\"]);",
+									"});"
+								]
+							}
+						}
+					]
 				},
 				{
 					"name": "Admin Automatically Sees Hidden Cruises",
@@ -4200,6 +4482,86 @@
 		{
 			"name": "Teardown",
 			"item": [
+				{
+					"name": "Delete Cruise-Hidden Lowering",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/lowerings/{{cruiseHiddenLoweringId}}",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"lowerings",
+								"{{cruiseHiddenLoweringId}}"
+							]
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Delete Cruise-Hidden Event",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/events/{{cruiseHiddenEventId}}",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"events",
+								"{{cruiseHiddenEventId}}"
+							]
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						}
+					]
+				},
 				{
 					"name": "Delete Event Auxiliary Data",
 					"event": [

--- a/integration-tests/api_tests.postman_collection.json
+++ b/integration-tests/api_tests.postman_collection.json
@@ -697,6 +697,114 @@
 							}
 						}
 					]
+				},
+				{
+					"name": "Create Hidden Lowering in Example Cruise",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/lowerings",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"lowerings"
+							]
+						},
+						"body": {
+							"mode": "raw",
+							"raw": "{\"lowering_id\": \"hidden-in-example\", \"start_ts\": \"2023-05-07T00:00:00.000Z\", \"stop_ts\": \"2023-05-08T00:00:00.000Z\", \"lowering_location\": \"Hidden Test Location\", \"lowering_hidden\": true, \"lowering_additional_meta\": {}, \"lowering_tags\": [\"hidden-tag\"]}"
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Response contains lowering ID\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property(\"insertedId\");",
+									"    pm.environment.set(\"hiddenInExampleLoweringId\", jsonData.insertedId);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Create Event in Hidden Lowering of Example Cruise",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/events",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"events"
+							]
+						},
+						"body": {
+							"mode": "raw",
+							"raw": "{\"event_author\": \"Admin\", \"ts\": \"2023-05-07T12:00:00.000Z\", \"event_value\": \"Hidden Lowering Event\", \"event_options\": [{\"event_option_name\": \"Test\", \"event_option_value\": \"Value\"}], \"event_free_text\": \"Event inside a hidden lowering within a non-hidden cruise\"}"
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Response contains event ID\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property(\"insertedId\");",
+									"    pm.environment.set(\"hiddenLoweringEventId\", jsonData.insertedId);",
+									"});"
+								]
+							}
+						}
+					]
 				}
 			]
 		},
@@ -3795,6 +3903,150 @@
 					]
 				},
 				{
+					"name": "Guest Events bycruise Excludes Hidden Lowering Events",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/events/bycruise/{{cruiseId}}",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"events",
+								"bycruise",
+								"{{cruiseId}}"
+							]
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"No events from hidden lowering in results\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    var hiddenLoweringEvents = jsonData.filter(function(e) {",
+									"        return e.event_value === \"Hidden Lowering Event\";",
+									"    });",
+									"    pm.expect(hiddenLoweringEvents.length).to.eql(0);",
+									"});",
+									"",
+									"pm.test(\"Normal events still present\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    var normalEvents = jsonData.filter(function(e) {",
+									"        return e.event_value === \"Example Event\";",
+									"    });",
+									"    pm.expect(normalEvents.length).to.be.above(0);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Guest Events bycruise Count Excludes Hidden Lowering Events",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/events/bycruise/{{cruiseId}}/count",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"events",
+								"bycruise",
+								"{{cruiseId}}",
+								"count"
+							]
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Count does not include hidden lowering events\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    // Only the single Example Event (ts within the non-hidden lowering) should be counted",
+									"    pm.expect(jsonData.events).to.eql(1);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Guest Event Exports bycruise Excludes Hidden Lowering Events",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/event_exports/bycruise/{{cruiseId}}",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"event_exports",
+								"bycruise",
+								"{{cruiseId}}"
+							]
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"No exports from hidden lowering in results\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    var hiddenEvents = jsonData.filter(function(e) {",
+									"        return e.event_value === \"Hidden Lowering Event\";",
+									"    });",
+									"    pm.expect(hiddenEvents.length).to.eql(0);",
+									"});",
+									"",
+									"pm.test(\"Normal event exports still present\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    var normalEvents = jsonData.filter(function(e) {",
+									"        return e.event_value === \"Example Event\";",
+									"    });",
+									"    pm.expect(normalEvents.length).to.be.above(0);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
 					"name": "Admin Automatically Sees Hidden Cruises",
 					"event": [
 						{
@@ -4482,6 +4734,86 @@
 		{
 			"name": "Teardown",
 			"item": [
+				{
+					"name": "Delete Hidden Lowering Event in Example Cruise",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/events/{{hiddenLoweringEventId}}",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"events",
+								"{{hiddenLoweringEventId}}"
+							]
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Delete Hidden Lowering in Example Cruise",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/lowerings/{{hiddenInExampleLoweringId}}",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"lowerings",
+								"{{hiddenInExampleLoweringId}}"
+							]
+						}
+					},
+					"response": [],
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						}
+					]
+				},
 				{
 					"name": "Delete Cruise-Hidden Lowering",
 					"request": {

--- a/lib/access_control.js
+++ b/lib/access_control.js
@@ -100,6 +100,27 @@ const annotateCruiseAccessDenied = async (lowerings, db, cruisesTable, request) 
   return lowerings;
 };
 
+// Return time ranges of hidden lowerings inside a cruise that the
+// requesting user cannot access.  Used by bycruise event handlers to
+// exclude events that fall within embargoed dives.
+const getHiddenLoweringRanges = async (db, loweringsTable, cruise, request) => {
+
+  const [, isAdmin] = getAuthzFlags(request);
+  if (isAdmin) return [];
+
+  const hiddenLowerings = await db.collection(loweringsTable).find({
+    lowering_hidden: true,
+    start_ts: { $gte: cruise.start_ts },
+    stop_ts: { $lte: cruise.stop_ts }
+  }).toArray();
+
+  if (hiddenLowerings.length === 0) return [];
+
+  return hiddenLowerings
+    .filter((l) => !checkEntityAccess(l, 'lowering', request))
+    .map((l) => ({ start_ts: l.start_ts, stop_ts: l.stop_ts }));
+};
+
 // Strip all fields from access_denied entities except id and the
 // human-readable identifier (cruise_id / lowering_id).
 const stripAccessDeniedFields = (entities, entityType) => {
@@ -130,5 +151,6 @@ module.exports = {
   annotateAccessDenied,
   annotateCruiseAccessDenied,
   findParentCruise,
+  getHiddenLoweringRanges,
   stripAccessDeniedFields
 };

--- a/lib/access_control.js
+++ b/lib/access_control.js
@@ -47,7 +47,88 @@ const checkEntityAccess = (entity, entityType, request) => {
   return false;
 };
 
+const annotateAccessDenied = (entities, entityType, request) => {
+
+  return entities.map((entity) => {
+
+    if (!checkEntityAccess(entity, entityType, request)) {
+      entity.access_denied = true;
+    }
+
+    return entity;
+  });
+};
+
+// Find the cruise whose time range encompasses the given lowering.
+// Returns the cruise document or null.
+const findParentCruise = async (db, cruisesTable, lowering) => {
+
+  return db.collection(cruisesTable).findOne({
+    start_ts: { $lte: lowering.start_ts },
+    stop_ts: { $gte: lowering.stop_ts }
+  });
+};
+
+// For lowering listings: if the parent cruise is hidden and the user
+// cannot access it, mark the lowering as access_denied.
+const annotateCruiseAccessDenied = async (lowerings, db, cruisesTable, request) => {
+
+  // Fetch all hidden cruises once
+  const hiddenCruises = await db.collection(cruisesTable).find({ cruise_hidden: true }).toArray();
+
+  if (hiddenCruises.length === 0) {
+    return lowerings;
+  }
+
+  lowerings.forEach((lowering) => {
+
+    // Already denied by lowering-level check, skip
+    if (lowering.access_denied) {
+      return;
+    }
+
+    // Check if this lowering falls within any hidden cruise
+    const parentCruise = hiddenCruises.find((cruise) =>
+      cruise.start_ts <= lowering.start_ts && cruise.stop_ts >= lowering.stop_ts
+    );
+
+    if (parentCruise && !checkEntityAccess(parentCruise, 'cruise', request)) {
+      lowering.access_denied = true;
+    }
+  });
+
+  return lowerings;
+};
+
+// Strip all fields from access_denied entities except id and the
+// human-readable identifier (cruise_id / lowering_id).
+const stripAccessDeniedFields = (entities, entityType) => {
+
+  const idField = `${entityType}_id`;
+
+  entities.forEach((entity) => {
+
+    if (!entity.access_denied) {
+      return;
+    }
+
+    // Flatten timestamps to date only (strip time component)
+    const toDateOnly = (ts) => ts ? new Date(ts).toISOString().split('T')[0] + 'T00:00:00.000Z' : undefined;
+    const keepFields = { id: entity.id, [idField]: entity[idField], start_ts: toDateOnly(entity.start_ts), access_denied: true };
+    if (entityType === 'cruise') {
+      keepFields.stop_ts = toDateOnly(entity.stop_ts);
+    }
+    const keep = keepFields;
+    Object.keys(entity).forEach((k) => delete entity[k]);
+    Object.assign(entity, keep);
+  });
+};
+
 module.exports = {
   initializeQuery,
-  checkEntityAccess
+  checkEntityAccess,
+  annotateAccessDenied,
+  annotateCruiseAccessDenied,
+  findParentCruise,
+  stripAccessDeniedFields
 };

--- a/lib/access_control.js
+++ b/lib/access_control.js
@@ -123,27 +123,30 @@ const getHiddenLoweringRanges = async (db, loweringsTable, cruise, request) => {
 
 // Strip all fields from access_denied entities except id and the
 // human-readable identifier (cruise_id / lowering_id).
-const stripAccessDeniedFields = (entities, entityType) => {
+const sanitizeUnauthorizedFields = (entities, entityType) => {
 
   const idField = `${entityType}_id`;
+  const toDateOnly = (ts) => ts ? new Date(ts).toISOString().split('T')[0] + 'T00:00:00.000Z' : undefined;
 
-  entities.forEach((entity) => {
+  return entities.map((entity) => {
 
     if (!entity.access_denied) {
-      return;
+      return entity;
     }
 
     // Flatten timestamps to date only (strip time component)
-    const toDateOnly = (ts) => ts ? new Date(ts).toISOString().split('T')[0] + 'T00:00:00.000Z' : undefined;
-    const keepFields = { id: entity.id, [idField]: entity[idField], start_ts: toDateOnly(entity.start_ts), access_denied: true };
+    const sanitized = { id: entity.id, [idField]: entity[idField], start_ts: toDateOnly(entity.start_ts), access_denied: true };
     if (entityType === 'cruise') {
-      keepFields.stop_ts = toDateOnly(entity.stop_ts);
+      sanitized.stop_ts = toDateOnly(entity.stop_ts);
     }
-    const keep = keepFields;
-    Object.keys(entity).forEach((k) => delete entity[k]);
-    Object.assign(entity, keep);
+
+    return sanitized;
   });
 };
+
+// Returns true if the event's timestamp falls within any of the given ranges.
+const isEventInHiddenRange = (event, hiddenRanges) =>
+  hiddenRanges.some((range) => event.ts >= range.start_ts && event.ts <= range.stop_ts);
 
 module.exports = {
   initializeQuery,
@@ -152,5 +155,6 @@ module.exports = {
   annotateCruiseAccessDenied,
   findParentCruise,
   getHiddenLoweringRanges,
-  stripAccessDeniedFields
+  sanitizeUnauthorizedFields,
+  isEventInHiddenRange
 };

--- a/routes/api/v1/cruises.js
+++ b/routes/api/v1/cruises.js
@@ -18,7 +18,7 @@ const {
   initializeQuery,
   checkEntityAccess,
   annotateAccessDenied,
-  stripAccessDeniedFields
+  sanitizeUnauthorizedFields
 } = require('../../../lib/access_control');
 
 const {
@@ -285,7 +285,7 @@ exports.plugin = {
           // console.log("cruises:", cruises);
           if (cruises.length > 0) {
 
-            const mod_cruises = cruises.map((cruise) => {
+            let mod_cruises = cruises.map((cruise) => {
 
               try {
                 cruise.cruise_additional_meta.cruise_files = Fs.readdirSync(CRUISE_PATH + '/' + cruise._id);
@@ -298,7 +298,7 @@ exports.plugin = {
             });
 
             annotateAccessDenied(mod_cruises, 'cruise', request);
-            stripAccessDeniedFields(mod_cruises, 'cruise');
+            mod_cruises = sanitizeUnauthorizedFields(mod_cruises, 'cruise');
 
             if (request.query.format && request.query.format === "csv") {
 

--- a/routes/api/v1/cruises.js
+++ b/routes/api/v1/cruises.js
@@ -16,7 +16,9 @@ const {
 
 const {
   initializeQuery,
-  checkEntityAccess
+  checkEntityAccess,
+  annotateAccessDenied,
+  stripAccessDeniedFields
 } = require('../../../lib/access_control');
 
 const {
@@ -161,10 +163,19 @@ const cruiseSuccessResponse = Joi.object({
   cruise_additional_meta: cruiseAdditionalMetaCreate,
   cruise_tags: Joi.array().items(cruiseTag),
   cruise_access_list: Joi.array().items(userID),
-  cruise_hidden: Joi.boolean()
+  cruise_hidden: Joi.boolean(),
+  access_denied: Joi.boolean().optional()
 }).label('cruiseSuccessResponse');
 
 const cruiseSuccessResponseNoAccessControl = cruiseSuccessResponse.keys({ cruise_access_list: Joi.forbidden() }).label('cruiseSuccessResponse');
+
+const cruiseAccessDeniedResponse = Joi.object({
+  id: Joi.object(),
+  cruise_id: Joi.string(),
+  start_ts: Joi.date().iso(),
+  stop_ts: Joi.date().iso(),
+  access_denied: Joi.boolean().valid(true).required()
+}).label('cruiseAccessDeniedResponse');
 
 const cruiseCreatePayload = Joi.object({
   id: Joi.string().length(24).optional(),
@@ -214,7 +225,7 @@ exports.plugin = {
         const db = request.mongo.db;
         // const ObjectID = request.mongo.ObjectID;
 
-        const query = initializeQuery(request, 'cruise');
+        const query = {};
 
         // Cruise ID filtering... if using this then there's no reason to use other filters
         if (request.query.cruise_id) {
@@ -286,6 +297,9 @@ exports.plugin = {
               return _renameAndClearFields(cruise);
             });
 
+            annotateAccessDenied(mod_cruises, 'cruise', request);
+            stripAccessDeniedFields(mod_cruises, 'cruise');
+
             if (request.query.format && request.query.format === "csv") {
 
               const flattenJSON = _flattenJSON(mod_cruises);
@@ -296,7 +310,7 @@ exports.plugin = {
 
               return h.response(csv_results).code(200);
             }
-            
+
             return h.response(mod_cruises).code(200);
           }
  
@@ -321,7 +335,10 @@ exports.plugin = {
           status: {
             200: Joi.alternatives().try(
               Joi.string(),
-              Joi.array().items((useAccessControl) ? cruiseSuccessResponse : cruiseSuccessResponseNoAccessControl)
+              Joi.array().items(Joi.alternatives().try(
+                (useAccessControl) ? cruiseSuccessResponse : cruiseSuccessResponseNoAccessControl,
+                cruiseAccessDeniedResponse
+              ))
             )
           }
         },

--- a/routes/api/v1/event_aux_data.js
+++ b/routes/api/v1/event_aux_data.js
@@ -4,7 +4,8 @@ const Joi = require('joi');
 const THRESHOLD = 120; //seconds
 
 const {
-  checkEntityAccess
+  checkEntityAccess,
+  findParentCruise
 } = require('../../../lib/access_control');
 
 const {
@@ -311,6 +312,12 @@ exports.plugin = {
           }
 
           if (!checkEntityAccess(loweringResult, 'lowering', request)) {
+            return Boom.unauthorized('User not authorized to retrieve this lowering');
+          }
+
+          // Check if the parent cruise is hidden
+          const parentCruise = await findParentCruise(db, cruisesTable, loweringResult);
+          if (parentCruise && !checkEntityAccess(parentCruise, 'cruise', request)) {
             return Boom.unauthorized('User not authorized to retrieve this lowering');
           }
 

--- a/routes/api/v1/event_aux_data.js
+++ b/routes/api/v1/event_aux_data.js
@@ -5,7 +5,8 @@ const THRESHOLD = 120; //seconds
 
 const {
   checkEntityAccess,
-  findParentCruise
+  findParentCruise,
+  getHiddenLoweringRanges
 } = require('../../../lib/access_control');
 
 const {
@@ -223,7 +224,13 @@ exports.plugin = {
         const eventQuery = _buildEventsQuery(request, cruise.start_ts, cruise.stop_ts);
 
         try {
-          const results = await db.collection(eventsTable).find(eventQuery, { _id: 1 }).sort( { ts: 1 } ).toArray();
+          let results = await db.collection(eventsTable).find(eventQuery, { _id: 1, ts: 1 }).sort( { ts: 1 } ).toArray();
+
+          // Filter out events that fall within hidden lowerings
+          const hiddenRanges = await getHiddenLoweringRanges(db, loweringsTable, cruise, request);
+          if (hiddenRanges.length > 0) {
+            results = results.filter((event) => !hiddenRanges.some((range) => event.ts >= range.start_ts && event.ts <= range.stop_ts));
+          }
 
           // EventID Filtering
           if (results.length > 0) {

--- a/routes/api/v1/event_aux_data.js
+++ b/routes/api/v1/event_aux_data.js
@@ -6,7 +6,8 @@ const THRESHOLD = 120; //seconds
 const {
   checkEntityAccess,
   findParentCruise,
-  getHiddenLoweringRanges
+  getHiddenLoweringRanges,
+  isEventInHiddenRange
 } = require('../../../lib/access_control');
 
 const {
@@ -229,7 +230,7 @@ exports.plugin = {
           // Filter out events that fall within hidden lowerings
           const hiddenRanges = await getHiddenLoweringRanges(db, loweringsTable, cruise, request);
           if (hiddenRanges.length > 0) {
-            results = results.filter((event) => !hiddenRanges.some((range) => event.ts >= range.start_ts && event.ts <= range.stop_ts));
+            results = results.filter((event) => !isEventInHiddenRange(event, hiddenRanges));
           }
 
           // EventID Filtering

--- a/routes/api/v1/event_exports.js
+++ b/routes/api/v1/event_exports.js
@@ -5,7 +5,8 @@ const { flattenEventJSON, convertToCSV } = require('./json_util');
 const {
   checkEntityAccess,
   findParentCruise,
-  getHiddenLoweringRanges
+  getHiddenLoweringRanges,
+  isEventInHiddenRange
 } = require('../../../lib/access_control');
 
 const {
@@ -230,7 +231,7 @@ exports.plugin = {
         // Filter out events that fall within hidden lowerings
         const hiddenRanges = await getHiddenLoweringRanges(db, loweringsTable, cruise, request);
         if (hiddenRanges.length > 0) {
-          results = results.filter((event) => !hiddenRanges.some((range) => event.ts >= range.start_ts && event.ts <= range.stop_ts));
+          results = results.filter((event) => !isEventInHiddenRange(event, hiddenRanges));
         }
 
         if (results.length > 0) {

--- a/routes/api/v1/event_exports.js
+++ b/routes/api/v1/event_exports.js
@@ -3,7 +3,8 @@ const Joi = require('joi');
 const { flattenEventJSON, convertToCSV } = require('./json_util');
 
 const {
-  checkEntityAccess
+  checkEntityAccess,
+  findParentCruise
 } = require('../../../lib/access_control');
 
 const {
@@ -318,6 +319,12 @@ exports.plugin = {
 
         // Check if user can access this lowering
         if (!checkEntityAccess(lowering, 'lowering', request)) {
+          return Boom.unauthorized('Not authorized to access this lowering');
+        }
+
+        // Check if the parent cruise is hidden
+        const parentCruise = await findParentCruise(db, cruisesTable, lowering);
+        if (parentCruise && !checkEntityAccess(parentCruise, 'cruise', request)) {
           return Boom.unauthorized('Not authorized to access this lowering');
         }
 

--- a/routes/api/v1/event_exports.js
+++ b/routes/api/v1/event_exports.js
@@ -4,7 +4,8 @@ const { flattenEventJSON, convertToCSV } = require('./json_util');
 
 const {
   checkEntityAccess,
-  findParentCruise
+  findParentCruise,
+  getHiddenLoweringRanges
 } = require('../../../lib/access_control');
 
 const {
@@ -224,6 +225,12 @@ exports.plugin = {
         catch (err) {
           console.log(err);
           return Boom.serverUnavailable('database error');
+        }
+
+        // Filter out events that fall within hidden lowerings
+        const hiddenRanges = await getHiddenLoweringRanges(db, loweringsTable, cruise, request);
+        if (hiddenRanges.length > 0) {
+          results = results.filter((event) => !hiddenRanges.some((range) => event.ts >= range.start_ts && event.ts <= range.stop_ts));
         }
 
         if (results.length > 0) {

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -9,7 +9,8 @@ const THRESHOLD = 120; //seconds
 const {
   checkEntityAccess,
   findParentCruise,
-  getHiddenLoweringRanges
+  getHiddenLoweringRanges,
+  isEventInHiddenRange
 } = require('../../../lib/access_control');
 
 const {
@@ -335,7 +336,7 @@ exports.plugin = {
         // Filter out events that fall within hidden lowerings
         const hiddenRanges = await getHiddenLoweringRanges(db, loweringsTable, cruise, request);
         if (hiddenRanges.length > 0) {
-          results = results.filter((event) => !hiddenRanges.some((range) => event.ts >= range.start_ts && event.ts <= range.stop_ts));
+          results = results.filter((event) => !isEventInHiddenRange(event, hiddenRanges));
         }
 
         if (results.length === 0) {
@@ -466,7 +467,7 @@ exports.plugin = {
         // Filter out events that fall within hidden lowerings
         const hiddenRanges = await getHiddenLoweringRanges(db, loweringsTable, cruise, request);
         if (hiddenRanges.length > 0) {
-          results = results.filter((event) => !hiddenRanges.some((range) => event.ts >= range.start_ts && event.ts <= range.stop_ts));
+          results = results.filter((event) => !isEventInHiddenRange(event, hiddenRanges));
         }
 
         if (results.length > 0) {

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -8,7 +8,8 @@ const THRESHOLD = 120; //seconds
 
 const {
   checkEntityAccess,
-  findParentCruise
+  findParentCruise,
+  getHiddenLoweringRanges
 } = require('../../../lib/access_control');
 
 const {
@@ -331,9 +332,15 @@ exports.plugin = {
           return Boom.serverUnavailable('database error');
         }
 
+        // Filter out events that fall within hidden lowerings
+        const hiddenRanges = await getHiddenLoweringRanges(db, loweringsTable, cruise, request);
+        if (hiddenRanges.length > 0) {
+          results = results.filter((event) => !hiddenRanges.some((range) => event.ts >= range.start_ts && event.ts <= range.stop_ts));
+        }
+
         if (results.length === 0) {
           return Boom.notFound('No records found' );
-        }      
+        }
 
         // --------- Data source filtering
         if (request.query.datasource) {
@@ -456,8 +463,14 @@ exports.plugin = {
           return Boom.serverUnavailable('database error');
         }
 
+        // Filter out events that fall within hidden lowerings
+        const hiddenRanges = await getHiddenLoweringRanges(db, loweringsTable, cruise, request);
+        if (hiddenRanges.length > 0) {
+          results = results.filter((event) => !hiddenRanges.some((range) => event.ts >= range.start_ts && event.ts <= range.stop_ts));
+        }
+
         if (results.length > 0) {
-        
+
           // --------- Data source filtering
           if (request.query.datasource) {
 

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -7,7 +7,8 @@ const escape = require('lodash.escape');
 const THRESHOLD = 120; //seconds
 
 const {
-  checkEntityAccess
+  checkEntityAccess,
+  findParentCruise
 } = require('../../../lib/access_control');
 
 const {
@@ -546,6 +547,12 @@ exports.plugin = {
             return Boom.unauthorized('Not authorized to access this lowering');
           }
 
+          // Check if the parent cruise is hidden
+          const parentCruise = await findParentCruise(db, cruisesTable, loweringResult);
+          if (parentCruise && !checkEntityAccess(parentCruise, 'cruise', request)) {
+            return Boom.unauthorized('Not authorized to access this lowering');
+          }
+
           lowering = loweringResult;
         }
         catch (err) {
@@ -669,6 +676,12 @@ exports.plugin = {
 
           // Check if user can access this lowering
           if (!checkEntityAccess(loweringResult, 'lowering', request)) {
+            return Boom.unauthorized('Not authorized to access this lowering');
+          }
+
+          // Check if the parent cruise is hidden
+          const parentCruise = await findParentCruise(db, cruisesTable, loweringResult);
+          if (parentCruise && !checkEntityAccess(parentCruise, 'cruise', request)) {
             return Boom.unauthorized('Not authorized to access this lowering');
           }
 

--- a/routes/api/v1/lowerings.js
+++ b/routes/api/v1/lowerings.js
@@ -20,7 +20,7 @@ const {
   annotateAccessDenied,
   annotateCruiseAccessDenied,
   findParentCruise,
-  stripAccessDeniedFields
+  sanitizeUnauthorizedFields
 } = require('../../../lib/access_control');
 
 const {
@@ -258,7 +258,7 @@ exports.plugin = {
 
           if (lowerings.length > 0) {
 
-            const mod_lowerings = lowerings.map((lowering) => {
+            let mod_lowerings = lowerings.map((lowering) => {
 
               try {
                 lowering.lowering_additional_meta.lowering_files = Fs.readdirSync(LOWERING_PATH + '/' + lowering._id);
@@ -272,7 +272,7 @@ exports.plugin = {
 
             annotateAccessDenied(mod_lowerings, 'lowering', request);
             await annotateCruiseAccessDenied(mod_lowerings, db, cruisesTable, request);
-            stripAccessDeniedFields(mod_lowerings, 'lowering');
+            mod_lowerings = sanitizeUnauthorizedFields(mod_lowerings, 'lowering');
 
             if (request.query.format && request.query.format === "csv") {
 
@@ -396,7 +396,7 @@ exports.plugin = {
 
           if (lowerings.length > 0) {
 
-            const mod_lowerings = lowerings.map((result) => {
+            let mod_lowerings = lowerings.map((result) => {
 
               try {
                 result.lowering_additional_meta.lowering_files = Fs.readdirSync(LOWERING_PATH + '/' + result._id);
@@ -416,7 +416,7 @@ exports.plugin = {
               mod_lowerings.forEach((l) => { l.access_denied = true; });
             }
 
-            stripAccessDeniedFields(mod_lowerings, 'lowering');
+            mod_lowerings = sanitizeUnauthorizedFields(mod_lowerings, 'lowering');
 
             if (request.query.format && request.query.format === "csv") {
 

--- a/routes/api/v1/lowerings.js
+++ b/routes/api/v1/lowerings.js
@@ -16,7 +16,11 @@ const {
 
 const {
   initializeQuery,
-  checkEntityAccess
+  checkEntityAccess,
+  annotateAccessDenied,
+  annotateCruiseAccessDenied,
+  findParentCruise,
+  stripAccessDeniedFields
 } = require('../../../lib/access_control');
 
 const {
@@ -171,10 +175,18 @@ const loweringSuccessResponse = Joi.object({
   lowering_tags: Joi.array().items(loweringTag),
   lowering_location: Joi.string().allow(''),
   lowering_access_list: Joi.array().items(userID),
-  lowering_hidden: Joi.boolean()
+  lowering_hidden: Joi.boolean(),
+  access_denied: Joi.boolean().optional()
 }).label('loweringSuccessResponse');
 
 const loweringSuccessResponseNoAccessControl = loweringSuccessResponse.keys({ lowering_access_list: Joi.forbidden() }).label('loweringSuccessResponse');
+
+const loweringAccessDeniedResponse = Joi.object({
+  id: Joi.object(),
+  lowering_id: Joi.string(),
+  start_ts: Joi.date().iso(),
+  access_denied: Joi.boolean().valid(true).required()
+}).label('loweringAccessDeniedResponse');
 
 const loweringUpdatePermissionsPayload = Joi.object({
   add: Joi.array().items(userID).optional(),
@@ -196,7 +208,7 @@ exports.plugin = {
 
         const db = request.mongo.db;
 
-        const query = initializeQuery(request, 'lowering');
+        const query = {};
 
         // Lowering ID filtering... if using this then there's no reason to use other filters
         if (request.query.lowering_id) {
@@ -258,6 +270,10 @@ exports.plugin = {
               return _renameAndClearFields(lowering);
             });
 
+            annotateAccessDenied(mod_lowerings, 'lowering', request);
+            await annotateCruiseAccessDenied(mod_lowerings, db, cruisesTable, request);
+            stripAccessDeniedFields(mod_lowerings, 'lowering');
+
             if (request.query.format && request.query.format === "csv") {
 
               const flattenJSON = _flattenJSON(mod_lowerings);
@@ -294,7 +310,10 @@ exports.plugin = {
           status: {
             200: Joi.alternatives().try(
               Joi.string(),
-              Joi.array().items((useAccessControl) ? loweringSuccessResponse : loweringSuccessResponseNoAccessControl)
+              Joi.array().items(Joi.alternatives().try(
+                (useAccessControl) ? loweringSuccessResponse : loweringSuccessResponseNoAccessControl,
+                loweringAccessDeniedResponse
+              ))
             )
           }
         },
@@ -328,7 +347,7 @@ exports.plugin = {
           return Boom.serverUnavailable('unknown error');
         }
 
-        const query = initializeQuery(request, 'lowering');
+        const query = {};
 
         // Lowering_id filtering
         if (request.query.lowering_id) {
@@ -389,6 +408,16 @@ exports.plugin = {
               return _renameAndClearFields(result);
             });
 
+            annotateAccessDenied(mod_lowerings, 'lowering', request);
+
+            // If the parent cruise is hidden and user can't access it,
+            // mark all its lowerings as access_denied
+            if (!checkEntityAccess(cruise, 'cruise', request)) {
+              mod_lowerings.forEach((l) => { l.access_denied = true; });
+            }
+
+            stripAccessDeniedFields(mod_lowerings, 'lowering');
+
             if (request.query.format && request.query.format === "csv") {
 
               const flattenJSON = _flattenJSON(mod_lowerings);
@@ -424,7 +453,10 @@ exports.plugin = {
           status: {
             200: Joi.alternatives().try(
               Joi.string(),
-              Joi.array().items((useAccessControl) ? loweringSuccessResponse : loweringSuccessResponseNoAccessControl)
+              Joi.array().items(Joi.alternatives().try(
+                (useAccessControl) ? loweringSuccessResponse : loweringSuccessResponseNoAccessControl,
+                loweringAccessDeniedResponse
+              ))
             )
           }
         },


### PR DESCRIPTION
Embargoed products are now listed on the cruise menu, but only metadata (date, id) is available and message displayed indicating how to get access.

Also adds checks to ensure exported events never include those belonging to a parents lowering or cruise that is hidden. Somewhat complex checks involved because of the nature of the database.

<img width="1153" height="895" alt="cruise-embargo" src="https://github.com/user-attachments/assets/603139e8-123f-4c5d-9304-eaa356c08e85" />
<img width="1137" height="553" alt="lowering-embargo" src="https://github.com/user-attachments/assets/49f18c05-3623-4618-8db5-986d67be0be2" />
