### PR TITLE
Allow upsert via event_aux_data PATCH handler

### DIFF
--- a/integration-tests/api_tests.postman_collection.json
+++ b/integration-tests/api_tests.postman_collection.json
@@ -2650,14 +2650,14 @@
 					"response": []
 				},
 				{
-					"name": "Update Event Auxiliary Data",
+					"name": "Patch Event Aux Data - nonexistent event_id returns 400",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"Status code is 204\", function () {",
-									"    pm.response.to.have.status(204);",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -2674,7 +2674,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"data_source\": \"Updated Data Source\"\n}",
+							"raw": "{\n  \"event_id\": \"aaaaaaaaaaaaaaaaaaaaaaaa\",\n  \"data_source\": \"testSource\",\n  \"data_array\": [\n    {\n      \"data_name\": \"test\",\n      \"data_value\": \"123\"\n    }\n  ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2698,19 +2698,14 @@
 					"response": []
 				},
 				{
-					"name": "Get Updated Event Auxiliary Data",
+					"name": "Patch Event Aux Data - new data_source creates record (201)",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Event auxiliary data is updated\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.data_source).to.eql(\"Updated Data Source\");",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -2718,13 +2713,70 @@
 						}
 					],
 					"request": {
-						"method": "GET",
+						"method": "PATCH",
 						"header": [
 							{
 								"key": "authorization",
 								"value": "{{jwt}}"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"event_id\": \"{{eventId}}\",\n  \"data_source\": \"patchTestSource\",\n  \"data_array\": [\n    {\n      \"data_name\": \"temperature\",\n      \"data_value\": \"22.5\",\n      \"data_uom\": \"celsius\"\n    }\n  ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/sealog-server/api/v1/event_aux_data/{{eventAuxDataId}}",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"sealog-server",
+								"api",
+								"v1",
+								"event_aux_data",
+								"{{eventAuxDataId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Patch Event Aux Data - existing data_source appends (204)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "authorization",
+								"value": "{{jwt}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"event_id\": \"{{eventId}}\",\n  \"data_source\": \"patchTestSource\",\n  \"data_array\": [\n    {\n      \"data_name\": \"pressure\",\n      \"data_value\": \"1013.25\",\n      \"data_uom\": \"hPa\"\n    }\n  ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
 							"raw": "{{baseURL}}/sealog-server/api/v1/event_aux_data/{{eventAuxDataId}}",
 							"host": [

--- a/routes/api/v1/event_aux_data.js
+++ b/routes/api/v1/event_aux_data.js
@@ -729,61 +729,47 @@ exports.plugin = {
           return Boom.badRequest('id must be a single String of 12 bytes or a string of 24 hex characters');
         }
 
-        let event_aux_data = null;
-        let result = null;
-
         try {
-          result = await db.collection(eventAuxDataTable).findOne(query);
+          const result = await db.collection(eventAuxDataTable).findOne(query);
 
           if (!result) {
             return Boom.notFound('No record found for id: ' + request.params.id);
           }
-
-          event_aux_data = request.payload;
-
         }
         catch (err) {
           return Boom.serverUnavailable('database error', err);
         }
 
+        let event_id;
         try {
-          event_aux_data.event_id = new ObjectID(request.payload.event_id);
+          event_id = new ObjectID(request.payload.event_id);
         }
         catch (err) {
           return Boom.badRequest('id must be a single String of 12 bytes or a string of 24 hex characters');
         }
 
-        if (event_aux_data.data_array) {
-          result.data_array.forEach((resultOption) => {
-
-            let foundit = false;
-            
-            event_aux_data.data_array.forEach((requestOption) => {
-
-              if (requestOption.data_name === resultOption.data_name) {
-                requestOption.data_value = resultOption.data_value;
-                
-                if (resultOption.data_uom) {
-                  requestOption.data_uom = resultOption.data_uom;
-                }
-
-                foundit = true;
-              }
-            });
-
-            if (!foundit) {
-              event_aux_data.data_array.push(resultOption);
-            }
-          });
-        }
-
         try {
-          await db.collection(eventAuxDataTable).updateOne( query, { $set: event_aux_data } );
-          return h.response().code(204);
+          const event = await db.collection(eventsTable).findOne({ _id: event_id });
+          if (!event) {
+            return Boom.badRequest('event not found for event_id: ' + request.payload.event_id);
+          }
         }
         catch (err) {
           return Boom.serverUnavailable('database error', err);
         }
+
+        const filter = { event_id, data_source: request.payload.data_source };
+
+        const update = {
+          $push: { data_array: { $each: request.payload.data_array } },
+          $setOnInsert: { event_id, data_source: request.payload.data_source },
+        };
+
+        const result = await db.collection(eventAuxDataTable).updateOne(
+          filter, update, { upsert: true }
+        );
+
+        return h.response().code(result.upsertedId ? 201 : 204);
       },
       config: {
         auth: {
@@ -793,7 +779,7 @@ exports.plugin = {
         validate: {
           headers: authorizationHeader,
           params: auxDataParam,
-          payload: auxDataUpdatePayload
+          payload: auxDataCreatePayload,
         },
         response: {
           status: {}


### PR DESCRIPTION
The frame grabber script has to perform grabs across different devices and then POST them as a single `vehicleRealtimeFramegrabberData` aux data entry.

This design is complex: it needs multiple worker threads to capture from each frame grabber simultaneously, and avoid one blocking the others, or taking down the whole script if one fails.

An API change to the server would improve this: it could allow `PATCH` requests with partial aux data. Then we would split each frame grabber instance into its own process, and the OS can do all the parallelism, and docker-compose can handle restarting on failure.

This is a breaking change by changing the semantics of the `PATCH` handler but I am reasonably confident there was no API user.